### PR TITLE
feat: Add decoders and encoders for NonEmptyList

### DIFF
--- a/src/main/scala/io/renku/jsonld/JsonLDDecoder.scala
+++ b/src/main/scala/io/renku/jsonld/JsonLDDecoder.scala
@@ -19,6 +19,7 @@
 package io.renku.jsonld
 
 import cats.syntax.all._
+import cats.data.NonEmptyList
 import io.circe.{DecodingFailure, JsonNumber}
 import io.renku.jsonld.Cursor._
 import io.renku.jsonld.JsonLD._
@@ -128,6 +129,12 @@ object JsonLDDecoder {
   }
 
   implicit def decodeList[I](implicit itemDecoder: JsonLDDecoder[I]): JsonLDDecoder[List[I]] = new JsonLDListDecoder[I]
+
+  implicit def decodeSet[I](implicit itemDecoder: JsonLDDecoder[I]): JsonLDDecoder[Set[I]] =
+    decodeList[I].emap(_.toSet.asRight)
+
+  implicit def decodeNonEmptyList[I](implicit dt: JsonLDDecoder[I]): JsonLDDecoder[NonEmptyList[I]] =
+    decodeList[I].emap(list => NonEmptyList.fromList(list).toRight(s"Expected a non-empty list"))
 }
 
 class JsonLDEntityDecoder[A](

--- a/src/main/scala/io/renku/jsonld/JsonLDEncoder.scala
+++ b/src/main/scala/io/renku/jsonld/JsonLDEncoder.scala
@@ -19,6 +19,8 @@
 package io.renku.jsonld
 
 import cats.Contravariant
+import cats.data.NonEmptyList
+import cats.syntax.contravariant._
 
 import java.time.{Instant, LocalDate}
 
@@ -55,6 +57,9 @@ object JsonLDEncoder {
       ordering:    Ordering[A]
   ): JsonLDEncoder[Set[A]] =
     (seq: Set[A]) => JsonLD.arr(seq.toList.sorted map (itemEncoder(_)): _*)
+
+  final implicit def encodeNonEmptyList[A](implicit itemEncoder: JsonLDEncoder[A]): JsonLDEncoder[NonEmptyList[A]] =
+    encodeList[A].contramap(_.toList)
 
   final implicit val encodeString:    JsonLDEncoder[String]    = (a: String) => JsonLD.fromString(a)
   final implicit val encodeInt:       JsonLDEncoder[Int]       = (a: Int) => JsonLD.fromInt(a)

--- a/src/test/scala/io/renku/jsonld/JsonLDDecoderSpec.scala
+++ b/src/test/scala/io/renku/jsonld/JsonLDDecoderSpec.scala
@@ -19,6 +19,7 @@
 package io.renku.jsonld
 
 import JsonLDDecoder._
+import cats.data.NonEmptyList
 import cats.syntax.all._
 import io.circe.DecodingFailure
 import io.renku.jsonld.Cursor.FlattenedJsonCursor
@@ -717,6 +718,16 @@ class JsonLDDecoderSpec
         .fold(fail(_), identity)
         .cursor
         .as[List[Parents]] shouldBe List(parents).asRight
+    }
+
+    "decode non-empty list successful" in {
+      val jsonLD = List(Child("child 1"), Child("child 2")).asJsonLD.flatten.fold(fail(_), identity)
+      jsonLD.cursor.as[NonEmptyList[Child]] shouldBe NonEmptyList.of(Child("child 1"), Child("child 2")).asRight
+    }
+
+    "decode non-empty list not successful" in {
+      val jsonLD = List.empty[Child].asJsonLD.flatten.fold(fail(_), identity)
+      jsonLD.cursor.as[NonEmptyList[Child]] shouldBe Left(DecodingFailure("Expected a non-empty list", Nil))
     }
   }
 


### PR DESCRIPTION
Also adds a decoder for `Set`, for which an encoder already exists.