### PR TITLE
feat: Improve emap on JsonLDEntityDecoder

### DIFF
--- a/src/main/scala/io/renku/jsonld/Cursor.scala
+++ b/src/main/scala/io/renku/jsonld/Cursor.scala
@@ -258,7 +258,7 @@ private[jsonld] sealed abstract class Caching(private[jsonld] val decodingCache:
       case _ => None
     }
 
-  def findInCache[A](implicit cacheableDecoder: CacheableEntityDecoder[A]): Option[A] =
+  def findInCache[A](implicit cacheableDecoder: CacheableEntityDecoder): Option[A] =
     findEntityId >>= decodingCache.get[A]
 
   def cache[A](entityId: EntityId, obj: A, decoder: JsonLDDecoder[A]): A = decoder match {
@@ -266,7 +266,7 @@ private[jsonld] sealed abstract class Caching(private[jsonld] val decodingCache:
     case _ => obj
   }
 
-  def cache[A](entityId: EntityId, obj: A)(implicit cacheableDecoder: CacheableEntityDecoder[A]): A =
+  def cache[A](entityId: EntityId, obj: A)(implicit cacheableDecoder: CacheableEntityDecoder): A =
     decodingCache.put(entityId, obj)
 
   def cache[A](json: JsonLD, obj: A, decoder: JsonLDDecoder[A]): A = json match {

--- a/src/main/scala/io/renku/jsonld/DecodingCache.scala
+++ b/src/main/scala/io/renku/jsonld/DecodingCache.scala
@@ -19,8 +19,8 @@
 package io.renku.jsonld
 
 trait DecodingCache {
-  def get[A](entityId: EntityId)(implicit cacheableDecoder: CacheableEntityDecoder[A]): Option[A]
-  def put[A](entityId: EntityId, obj:                       A)(implicit cacheableDecoder: CacheableEntityDecoder[A]): A
+  def get[A](entityId: EntityId)(implicit cacheableDecoder: CacheableEntityDecoder): Option[A]
+  def put[A](entityId: EntityId, obj:                       A)(implicit cacheableDecoder: CacheableEntityDecoder): A
 }
 
 object DecodingCache {
@@ -31,23 +31,23 @@ object DecodingCache {
 
     import collection.mutable
 
-    private case class CacheKey(entityId: EntityId, decoder: CacheableEntityDecoder.Yes[_])
+    private case class CacheKey(entityId: EntityId, decoder: CacheableEntityDecoder.Yes)
 
     private val cache: mutable.Map[CacheKey, Any] = mutable.Map.empty[CacheKey, Any]
 
-    override def get[A](entityId: EntityId)(implicit cacheableDecoder: CacheableEntityDecoder[A]): Option[A] =
+    override def get[A](entityId: EntityId)(implicit cacheableDecoder: CacheableEntityDecoder): Option[A] =
       cacheableDecoder match {
-        case decoder: CacheableEntityDecoder.Yes[A] =>
+        case decoder: CacheableEntityDecoder.Yes =>
           cache.get(CacheKey(entityId, decoder)).map(_.asInstanceOf[A])
-        case _: CacheableEntityDecoder.No[A] => None
+        case _: CacheableEntityDecoder.No.type => None
       }
 
-    override def put[A](entityId: EntityId, obj: A)(implicit cacheableDecoder: CacheableEntityDecoder[A]): A =
+    override def put[A](entityId: EntityId, obj: A)(implicit cacheableDecoder: CacheableEntityDecoder): A =
       cacheableDecoder match {
-        case decoder: CacheableEntityDecoder.Yes[A] =>
+        case decoder: CacheableEntityDecoder.Yes =>
           cache.addOne(CacheKey(entityId, decoder) -> obj)
           obj
-        case _: CacheableEntityDecoder.No[A] => obj
+        case _: CacheableEntityDecoder.No.type => obj
       }
   }
 }

--- a/src/main/scala/io/renku/jsonld/JsonLDDecoder.scala
+++ b/src/main/scala/io/renku/jsonld/JsonLDDecoder.scala
@@ -35,6 +35,8 @@ trait JsonLDDecoder[A] extends (Cursor => Result[A]) with Serializable {
 
   def emap[B](f: A => Either[String, B]): JsonLDDecoder[B] =
     this(_).flatMap(f(_).leftMap(DecodingFailure(_, Nil)))
+
+  def map[B](f: A => B): JsonLDDecoder[B] = emap(f.andThen(Right(_)))
 }
 
 object JsonLDDecoder {

--- a/src/main/scala/io/renku/jsonld/JsonLDDecoder.scala
+++ b/src/main/scala/io/renku/jsonld/JsonLDDecoder.scala
@@ -147,6 +147,11 @@ class JsonLDEntityDecoder[A](
   implicit lazy val cacheableDecoder: CacheableEntityDecoder =
     if (useCache) CacheableEntityDecoder.Yes(this) else CacheableEntityDecoder.No
 
+  override def emap[B](fn: A => Either[String, B]): JsonLDEntityDecoder[B] =
+    new JsonLDEntityDecoder[B](entityTypes, predicate, useCache)(
+      f.andThen(_.flatMap(v => fn(v).left.map(DecodingFailure(_, Nil))))
+    )
+
   override def apply(cursor: Cursor): Result[A] = cursor match {
     case cur: FlattenedJsonCursor => tryDecode(cur) getOrElse cannotDecodeToEntityTypes(cur)
     case _ => goDownType(cursor)

--- a/src/test/scala/io/renku/jsonld/CursorSpec.scala
+++ b/src/test/scala/io/renku/jsonld/CursorSpec.scala
@@ -244,12 +244,12 @@ class CursorSpec extends AnyWordSpec with ScalaCheckPropertyChecks with should.M
     "reach the cache for JsonLDEntityDecoder" in new TestCase {
       val decoder =
         JsonLDDecoder.cacheableEntity[String](entityTypesObject.generateOne)(_ => nonEmptyStrings().generateOne.asRight)
-      val entity @ JsonLDEntity(id, _, _, _) = jsonLDEntities.generateOne
+      val entity = jsonLDEntities.generateOne
 
       val fromCache = nonEmptyStrings().generateOne.some
       (decodingCache
-        .get(_: EntityId)(_: CacheableEntityDecoder[String]))
-        .expects(id, decoder.cacheableDecoder)
+        .get[String](_: EntityId)(_: CacheableEntityDecoder))
+        .expects(entity.id, decoder.cacheableDecoder)
         .returning(fromCache)
 
       Cursor.TopCursor(entity).findInCache(decoder) shouldBe fromCache
@@ -272,7 +272,7 @@ class CursorSpec extends AnyWordSpec with ScalaCheckPropertyChecks with should.M
 
       val fromCache = nonEmptyStrings().generateOne.some
       (decodingCache
-        .get(_: EntityId)(_: CacheableEntityDecoder[String]))
+        .get[String](_: EntityId)(_: CacheableEntityDecoder))
         .expects(id, decoder.cacheableDecoder)
         .returning(fromCache)
 
@@ -281,9 +281,9 @@ class CursorSpec extends AnyWordSpec with ScalaCheckPropertyChecks with should.M
 
     "do not reach the cache for a non-JsonLDEntityDecoder" in new TestCase {
       val decoder = JsonLDDecoder.instance[String](_ => nonEmptyStrings().generateOne.asRight)
-      val entity @ JsonLDEntity(id, _, _, _) = jsonLDEntities.generateOne
+      val entity  = jsonLDEntities.generateOne
 
-      Cursor.TopCursor(entity).findInCache(id, decoder) shouldBe None
+      Cursor.TopCursor(entity).findInCache[String](entity.id, decoder) shouldBe None
     }
   }
 
@@ -296,7 +296,7 @@ class CursorSpec extends AnyWordSpec with ScalaCheckPropertyChecks with should.M
 
       val fromCache = nonEmptyStrings().generateOne.some
       (decodingCache
-        .get(_: EntityId)(_: CacheableEntityDecoder[String]))
+        .get[String](_: EntityId)(_: CacheableEntityDecoder))
         .expects(id, decoder.cacheableDecoder)
         .returning(fromCache)
 
@@ -314,7 +314,7 @@ class CursorSpec extends AnyWordSpec with ScalaCheckPropertyChecks with should.M
       val obj      = nonEmptyStrings().generateOne
 
       (decodingCache
-        .put[String](_: EntityId, _: String)(_: CacheableEntityDecoder[String]))
+        .put[String](_: EntityId, _: String)(_: CacheableEntityDecoder))
         .expects(entityId, obj, decoder.cacheableDecoder)
         .returning(obj)
 
@@ -341,7 +341,7 @@ class CursorSpec extends AnyWordSpec with ScalaCheckPropertyChecks with should.M
       val obj      = nonEmptyStrings().generateOne
 
       (decodingCache
-        .put[String](_: EntityId, _: String)(_: CacheableEntityDecoder[String]))
+        .put[String](_: EntityId, _: String)(_: CacheableEntityDecoder))
         .expects(entityId, obj, decoder.cacheableDecoder)
         .returning(obj)
 
@@ -359,7 +359,7 @@ class CursorSpec extends AnyWordSpec with ScalaCheckPropertyChecks with should.M
       val obj                                = nonEmptyStrings().generateOne
 
       (decodingCache
-        .put[String](_: EntityId, _: String)(_: CacheableEntityDecoder[String]))
+        .put[String](_: EntityId, _: String)(_: CacheableEntityDecoder))
         .expects(id, obj, decoder.cacheableDecoder)
         .returning(obj)
 
@@ -396,7 +396,7 @@ class CursorSpec extends AnyWordSpec with ScalaCheckPropertyChecks with should.M
       val obj                                = nonEmptyStrings().generateOne
 
       (decodingCache
-        .put[String](_: EntityId, _: String)(_: CacheableEntityDecoder[String]))
+        .put[String](_: EntityId, _: String)(_: CacheableEntityDecoder))
         .expects(id, obj, decoder.cacheableDecoder)
         .returning(obj)
 

--- a/src/test/scala/io/renku/jsonld/DecodingCacheSpec.scala
+++ b/src/test/scala/io/renku/jsonld/DecodingCacheSpec.scala
@@ -33,7 +33,7 @@ class DecodingCacheSpec extends AnyWordSpec with should.Matchers with ScalaCheck
 
     "cache the value for a CacheableEntityDecoder" in new TestCase {
       forAll { (entityId: EntityId, obj: Int) =>
-        implicit val cacheableDecoder: CacheableEntityDecoder[Int] = newCacheableDecoder()
+        implicit val cacheableDecoder: CacheableEntityDecoder = newCacheableDecoder()
 
         cache.put(entityId, obj) shouldBe obj
 
@@ -43,7 +43,7 @@ class DecodingCacheSpec extends AnyWordSpec with should.Matchers with ScalaCheck
 
     "do not cache the value for a non-CacheableEntityDecoder" in new TestCase {
       forAll { (entityId: EntityId, obj: Int) =>
-        implicit val nonCacheableDecoder: CacheableEntityDecoder[Int] = newNonCacheableDecoder()
+        implicit val nonCacheableDecoder: CacheableEntityDecoder = newNonCacheableDecoder()
 
         cache.put(entityId, obj) shouldBe obj
 
@@ -55,13 +55,13 @@ class DecodingCacheSpec extends AnyWordSpec with should.Matchers with ScalaCheck
 
       val entityId = entityIds.generateOne
 
-      val cacheableDecoder1: CacheableEntityDecoder[Int] = newCacheableDecoder()
+      val cacheableDecoder1: CacheableEntityDecoder = newCacheableDecoder()
       val obj1 = Arbitrary.arbInt.arbitrary.generateOne
 
-      val cacheableDecoder2: CacheableEntityDecoder[Int] = newCacheableDecoder()
+      val cacheableDecoder2: CacheableEntityDecoder = newCacheableDecoder()
       val obj2 = Arbitrary.arbInt.arbitrary.generateOne
 
-      val nonCacheableDecoder: CacheableEntityDecoder[Int] = newNonCacheableDecoder()
+      val nonCacheableDecoder: CacheableEntityDecoder = newNonCacheableDecoder()
       val nonCachedObj = Arbitrary.arbInt.arbitrary.generateOne
 
       cache.put(entityId, obj1)(cacheableDecoder1)           shouldBe obj1

--- a/src/test/scala/io/renku/jsonld/JsonLDDecoderSpec.scala
+++ b/src/test/scala/io/renku/jsonld/JsonLDDecoderSpec.scala
@@ -115,6 +115,15 @@ class JsonLDDecoderSpec
     }
   }
 
+  "map" should {
+    "appy the given function" in {
+      forAll { value: String =>
+        val decoder = decodeString.map(_.length)
+        JsonLD.fromString(value).cursor.as[Int](decoder) shouldBe Right(value.length)
+      }
+    }
+  }
+
   "implicit decoders" should {
 
     val scenarios = Table(

--- a/src/test/scala/io/renku/jsonld/JsonLDDecoderSpec.scala
+++ b/src/test/scala/io/renku/jsonld/JsonLDDecoderSpec.scala
@@ -59,6 +59,60 @@ class JsonLDDecoderSpec
         JsonLD.fromString(value).cursor.as[Int](decoder).leftMap(_.message) shouldBe Left(message)
       }
     }
+
+    case class Person(name: String)
+
+    "return a JsonLDEntityDecoder as result when called on JsonLDEntityDecoder" in {
+      val decoder: JsonLDEntityDecoder[Person] = JsonLDDecoder.entity(EntityTypes.of(schema / "Person")) { cursor =>
+        cursor.downField(schema / "name").as[String].map(Person)
+      }
+
+      val result = decoder.emap(p => Person(p.name.reverse).asRight)
+      result.getClass shouldBe decoder.getClass
+    }
+
+    "apply the function when called on JsonLDEntityDecoder" in {
+      forAll(Gen.alphaNumStr) { value: String =>
+        val decoder: JsonLDEntityDecoder[Person] = JsonLDDecoder.entity(EntityTypes.of(schema / "Person")) { cursor =>
+          cursor.downField(schema / "name").as[String].map(Person)
+        }
+
+        val result = decoder.emap(p => Person(p.name.reverse).asRight)
+
+        val decoded = parser
+          .parse(s"""{
+                    |  "@id" : "http://bla.org/persons/$value",
+                    |  "@type" : [ "http://io.renku/Person" ],
+                    |  "http://io.renku/name" : {
+                    |    "@value" : "$value"
+                    |  }
+                    |}""".stripMargin)
+          .flatMap(_.cursor.as[Person](result))
+          .fold(throw _, identity)
+
+        decoded shouldBe Person(value.reverse)
+      }
+    }
+
+    "fail if emap is returning a Left on JsonLDEntityDecoder" in {
+      val decoder: JsonLDEntityDecoder[Person] = JsonLDDecoder.entity(EntityTypes.of(schema / "Person")) { cursor =>
+        cursor.downField(schema / "name").as[String].map(Person)
+      }
+
+      val result: JsonLDEntityDecoder[Person] = decoder.emap(_ => Left("error!!"))
+      val decodingError = parser
+        .parse(s"""{
+                  |  "@id" : "http://bla.org/persons/$value",
+                  |  "@type" : [ "http://io.renku/Person" ],
+                  |  "http://io.renku/name" : {
+                  |    "@value" : "$value"
+                  |  }
+                  |}""".stripMargin)
+        .flatMap(_.cursor.as[Person](result))
+        .fold(identity, p => fail(s"Expected decode to fail, but got: $p"))
+
+      decodingError.getMessage shouldBe "error!!"
+    }
   }
 
   "implicit decoders" should {


### PR DESCRIPTION
*Refactor decoding cache internals*

In order to prepare for a emap operation on the JsonLDEntityDecoder,
the cache-factory has been turned into a flag. The factory was only
used with `this`, so creating the CacheableDecoder is now inside the
JsonLDEntityDecoder.

Made the DecodingCache a bit more inconvenient to use by removing the
type parameter. This was used to help with type inference. Now you
need to specify the type explicitely. But it allows for better reuse,
of the global cache. It stores all kind of objects not only ones of a
certain type.

*emap / map*

`emap` retains the return type when called on JsonLDEnittyDecoder, so
the information of entitytypes and predicates are kept. Also adds a simpler
variant `map` to allow mapping with pure functions.
