### PR TITLE
Added support for scala 2.12.12

### DIFF
--- a/.github/workflows/test-and-publish.yml
+++ b/.github/workflows/test-and-publish.yml
@@ -33,7 +33,7 @@ jobs:
             ~/.sbt
           key: ${{ runner.os }}-sbt-${{ hashFiles('**/build.sbt') }}
       - name: Unit test
-        run: sbt -Dsbt.color=always -Dsbt.supershell=false clean test
+        run: sbt -Dsbt.color=always -Dsbt.supershell=false clean +test
   examples:
     name: Run Examples
     runs-on: ubuntu-latest
@@ -53,7 +53,7 @@ jobs:
             ~/.sbt
           key: ${{ runner.os }}-sbt-${{ hashFiles('**/build.sbt') }}
       - name: Run Examples
-        run: sbt -Dsbt.color=always -Dsbt.supershell=false clean "Examples / test"
+        run: sbt -Dsbt.color=always -Dsbt.supershell=false clean +"Examples / test"
   formatter:
     name: Formatter
     runs-on: ubuntu-latest
@@ -73,7 +73,7 @@ jobs:
             ~/.sbt
           key: ${{ runner.os }}-sbt-${{ hashFiles('**/build.sbt') }}
       - name: Formatter
-        run: sbt scalafmtCheck
+        run: sbt +scalafmtCheck
   publish:
     name: Publish
     runs-on: ubuntu-20.04 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
             ~/.sbt
           key: ${{ runner.os }}-sbt-${{ hashFiles('**/build.sbt') }}
       - name: Unit test
-        run: sbt -Dsbt.color=always -Dsbt.supershell=false clean test
+        run: sbt -Dsbt.color=always -Dsbt.supershell=false clean +test
   formatter:
     name: Formatter
     runs-on: ubuntu-latest
@@ -67,4 +67,4 @@ jobs:
             ~/.sbt
           key: ${{ runner.os }}-sbt-${{ hashFiles('**/build.sbt') }}
       - name: Formatter
-        run: sbt scalafmtCheck
+        run: sbt +scalafmtCheck

--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,7 @@ lazy val root = Project(
     organization := "io.renku",
     name := "jsonld4s",
     crossScalaVersions := Seq("2.13.10", "2.12.12"),
-    scalaVersion := "2.12.12",
+    scalaVersion := "2.13.10",
     inConfig(Examples)(Defaults.testSettings)
   )
   .enablePlugins(AutomateHeaderPlugin)

--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,8 @@ lazy val root = Project(
   .settings(
     organization := "io.renku",
     name := "jsonld4s",
-    scalaVersion := "2.13.10",
+    crossScalaVersions := Seq("2.13.10", "2.12.12"),
+    scalaVersion := "2.12.12",
     inConfig(Examples)(Defaults.testSettings)
   )
   .enablePlugins(AutomateHeaderPlugin)
@@ -54,6 +55,7 @@ inThisBuild(
     licenses := List("Apache 2.0" -> new URL("http://www.apache.org/licenses/")),
     description := "Scala Circe extension for JSON-LD",
     homepage := Some(url("https://github.com/SwissDataScienceCenter/jsonld4s")),
+    addCompilerPlugin("org.typelevel" % "kind-projector" % "0.13.2" cross CrossVersion.full),
     developers := List(
       Developer(
         id = "SwissDataScienceCenter",

--- a/build.sbt
+++ b/build.sbt
@@ -94,3 +94,6 @@ headerLicense := Some(
         |limitations under the License.""".stripMargin
   )
 )
+
+addCommandAlias("testAll", "+ test")
+

--- a/src/main/scala-2.12/io/renku/jsonld/compat/implicits.scala
+++ b/src/main/scala-2.12/io/renku/jsonld/compat/implicits.scala
@@ -2,7 +2,9 @@ package io.renku.jsonld.compat
 
 import scala.collection.mutable
 import scala.collection.immutable
-import cats.{Alternative, Eval, Foldable}
+import cats.{Alternative, Eval, Foldable, Traverse}
+
+import scala.language.higherKinds
 
 object implicits {
 
@@ -31,6 +33,10 @@ object implicits {
       }
       m.toMap
     }
+  }
+
+  implicit class TraverseOpsEitherCompat[F[_], A, B](val value: F[Either[A, B]]) extends AnyVal {
+    def sequence(implicit F: Traverse[F]): Either[A, F[B]] = F.sequence[Either[A, *], B](value)
   }
 
 }

--- a/src/main/scala-2.12/io/renku/jsonld/compat/implicits.scala
+++ b/src/main/scala-2.12/io/renku/jsonld/compat/implicits.scala
@@ -1,0 +1,36 @@
+package io.renku.jsonld.compat
+
+import scala.collection.mutable
+import scala.collection.immutable
+import cats.{Alternative, Eval, Foldable}
+
+object implicits {
+
+  implicit def catsImplicitForSeq: Foldable[Seq] with Alternative[Seq] =
+    new Foldable[Seq] with Alternative[Seq] {
+      override def foldLeft[A, B](fa: Seq[A], b: B)(f: (B, A) => B): B = fa.foldLeft(b)(f)
+      override def foldRight[A, B](fa: Seq[A], lb: Eval[B])(f: (A, Eval[B]) => Eval[B]): Eval[B] =
+        Foldable.iterateRight(fa, lb)(f)
+      override def pure[A](x: A): Seq[A] = Seq(x)
+      override def empty[A]: Seq[A] = Seq.empty
+      override def combineK[A](x: Seq[A], y: Seq[A]): Seq[A] = x ++ y
+      override def ap[A, B](ff: Seq[A => B])(fa: Seq[A]): Seq[B] = ff.flatMap(f => fa.map(f))
+    }
+
+  implicit class IterableOpsCompat[A](val iterable: Iterable[A]) extends AnyVal {
+    def groupMapReduce[K, B](key: A => K)(f: A => B)(reduce: (B, B) => B): immutable.Map[K, B] = {
+      val m = mutable.Map.empty[K, B]
+      for (elem <- iterable) {
+        val k = key(elem)
+        val v =
+          m.get(k) match {
+            case Some(b) => reduce(b, f(elem))
+            case None => f(elem)
+          }
+        m.put(k, v)
+      }
+      m.toMap
+    }
+  }
+
+}

--- a/src/main/scala-2.12/io/renku/jsonld/compat/implicits.scala
+++ b/src/main/scala-2.12/io/renku/jsonld/compat/implicits.scala
@@ -32,8 +32,8 @@ object implicits {
         Foldable.iterateRight(fa, lb)(f)
       override def pure[A](x: A): Seq[A] = Seq(x)
       override def empty[A]: Seq[A] = Seq.empty
-      override def combineK[A](x: Seq[A], y: Seq[A]): Seq[A] = x ++ y
-      override def ap[A, B](ff: Seq[A => B])(fa: Seq[A]): Seq[B] = ff.flatMap(f => fa.map(f))
+      override def combineK[A](x: Seq[A], y:       Seq[A]): Seq[A] = x ++ y
+      override def ap[A, B](ff:   Seq[A => B])(fa: Seq[A]): Seq[B] = ff.flatMap(f => fa.map(f))
     }
 
   implicit class IterableOpsCompat[A](val iterable: Iterable[A]) extends AnyVal {
@@ -44,7 +44,7 @@ object implicits {
         val v =
           m.get(k) match {
             case Some(b) => reduce(b, f(elem))
-            case None => f(elem)
+            case None    => f(elem)
           }
         m.put(k, v)
       }

--- a/src/main/scala-2.12/io/renku/jsonld/compat/implicits.scala
+++ b/src/main/scala-2.12/io/renku/jsonld/compat/implicits.scala
@@ -39,4 +39,11 @@ object implicits {
     def sequence(implicit F: Traverse[F]): Either[A, F[B]] = F.sequence[Either[A, *], B](value)
   }
 
+  implicit class FlatMapOpsEitherCompat[A, B](val value: Either[A, B]) extends AnyVal {
+    def >>=[C](f: B => Either[A, C]): Either[A, C] = value match {
+      case Left(a)  => Left(a)
+      case Right(b) => f(b)
+    }
+  }
+
 }

--- a/src/main/scala-2.12/io/renku/jsonld/compat/implicits.scala
+++ b/src/main/scala-2.12/io/renku/jsonld/compat/implicits.scala
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.renku.jsonld.compat
 
 import scala.collection.{IterableView, immutable, mutable}

--- a/src/main/scala-2.12/io/renku/jsonld/compat/implicits.scala
+++ b/src/main/scala-2.12/io/renku/jsonld/compat/implicits.scala
@@ -1,7 +1,6 @@
 package io.renku.jsonld.compat
 
-import scala.collection.mutable
-import scala.collection.immutable
+import scala.collection.{IterableView, immutable, mutable}
 import cats.{Alternative, Eval, Foldable, Traverse}
 
 import scala.language.higherKinds
@@ -44,6 +43,10 @@ object implicits {
       case Left(a)  => Left(a)
       case Right(b) => f(b)
     }
+  }
+
+  implicit class IterableViewOpsCompat[K, V](val value: IterableView[(K, V), Map[K, V]]) extends AnyVal {
+    def filterKeys(p: K => Boolean): Map[K, V] = value.filter { case (k, _) => p(k) }.toMap
   }
 
 }

--- a/src/main/scala-2.13/io/renku/jsonld/compat/implicits.scala
+++ b/src/main/scala-2.13/io/renku/jsonld/compat/implicits.scala
@@ -18,6 +18,4 @@
 
 package io.renku.jsonld.compat
 
-object implicits {
-
-}
+object implicits {}

--- a/src/main/scala-2.13/io/renku/jsonld/compat/implicits.scala
+++ b/src/main/scala-2.13/io/renku/jsonld/compat/implicits.scala
@@ -1,0 +1,5 @@
+package io.renku.jsonld.compat
+
+object implicits {
+
+}

--- a/src/main/scala-2.13/io/renku/jsonld/compat/implicits.scala
+++ b/src/main/scala-2.13/io/renku/jsonld/compat/implicits.scala
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2023 Swiss Data Science Center (SDSC)
+ * A partnership between École Polytechnique Fédérale de Lausanne (EPFL) and
+ * Eidgenössische Technische Hochschule Zürich (ETHZ).
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.renku.jsonld.compat
 
 object implicits {

--- a/src/main/scala/io/renku/jsonld/Cursor.scala
+++ b/src/main/scala/io/renku/jsonld/Cursor.scala
@@ -193,7 +193,7 @@ object Cursor {
     override lazy val delete: Cursor = this
     override lazy val top: Option[JsonLD] = parent.jsonLD match {
       case json @ JsonLDEntity(_, _, properties, _) =>
-        Some(json.copy(properties = properties.removed(property)))
+        Some(json.copy(properties = properties - property))
     }
     override lazy val focusTop: Cursor = top.map(TopCursor(_)).getOrElse(this)
   }

--- a/src/main/scala/io/renku/jsonld/DecodingCache.scala
+++ b/src/main/scala/io/renku/jsonld/DecodingCache.scala
@@ -45,7 +45,7 @@ object DecodingCache {
     override def put[A](entityId: EntityId, obj: A)(implicit cacheableDecoder: CacheableEntityDecoder): A =
       cacheableDecoder match {
         case decoder: CacheableEntityDecoder.Yes =>
-          cache.addOne(CacheKey(entityId, decoder) -> obj)
+          cache += (CacheKey(entityId, decoder) -> obj)
           obj
         case _: CacheableEntityDecoder.No.type => obj
       }

--- a/src/main/scala/io/renku/jsonld/EntityId.scala
+++ b/src/main/scala/io/renku/jsonld/EntityId.scala
@@ -57,7 +57,7 @@ object EntityId {
   implicit val entityIdJsonDecoder: Decoder[EntityId] = Decoder.instance {
     _.as[String].map {
       case s if s.startsWith("_:") => EntityId.BlankNodeEntityId(UUID.fromString(s.substring(2)))
-      case s            => EntityId.of(s)
+      case s                       => EntityId.of(s)
     }
   }
 

--- a/src/main/scala/io/renku/jsonld/EntityId.scala
+++ b/src/main/scala/io/renku/jsonld/EntityId.scala
@@ -56,7 +56,7 @@ object EntityId {
 
   implicit val entityIdJsonDecoder: Decoder[EntityId] = Decoder.instance {
     _.as[String].map {
-      case s"_:${uuid}" => EntityId.BlankNodeEntityId(UUID.fromString(uuid))
+      case s if s.startsWith("_:") => EntityId.BlankNodeEntityId(UUID.fromString(s.substring(2)))
       case s            => EntityId.of(s)
     }
   }

--- a/src/main/scala/io/renku/jsonld/JsonLD.scala
+++ b/src/main/scala/io/renku/jsonld/JsonLD.scala
@@ -22,9 +22,9 @@ import cats.syntax.all._
 import io.circe.{Encoder, Json, JsonNumber}
 import io.renku.jsonld.flatten.{JsonLDArrayFlatten, JsonLDEntityFlatten, JsonLDFlatten}
 import io.renku.jsonld.merge.{EntitiesMerger, JsonLDMerge}
-
 import java.io.Serializable
 import java.time.{Instant, LocalDate}
+import io.renku.jsonld.compat.implicits._
 
 abstract class JsonLD extends JsonLDMerge with JsonLDFlatten with Product with Serializable {
 

--- a/src/main/scala/io/renku/jsonld/JsonLDDecoder.scala
+++ b/src/main/scala/io/renku/jsonld/JsonLDDecoder.scala
@@ -285,9 +285,9 @@ private[jsonld] class JsonLDListDecoder[I](implicit itemDecoder: JsonLDDecoder[I
     case Right(cached) => cached.asRight[DecodingFailure]
     case Left(entity @ JsonLDEntity(id, _, _, _)) =>
       val cursor = cursorFactory(entity)
-      itemDecoder(cursor)
-        .leftMap(failure => DecodingFailure(show"Cannot decode entity with $id: $failure", Nil))
-        .flatMap(i => cursor.cache(entity, i, itemDecoder).asRight[DecodingFailure].map(_ => i))
+      (itemDecoder(cursor)
+        .leftMap(failure => DecodingFailure(show"Cannot decode entity with $id: $failure", Nil)): Result[I])
+        .flatTap(cursor.cache(entity, _, itemDecoder).asRight[DecodingFailure])
   }
 
   private def decodeIfFlattenedCursor(cursor: FlattenedJsonCursor): Result[List[I]] = cursor.jsonLD match {

--- a/src/main/scala/io/renku/jsonld/JsonLDDecoder.scala
+++ b/src/main/scala/io/renku/jsonld/JsonLDDecoder.scala
@@ -24,7 +24,7 @@ import io.circe.{DecodingFailure, JsonNumber}
 import io.renku.jsonld.Cursor._
 import io.renku.jsonld.JsonLD._
 import io.renku.jsonld.JsonLDDecoder.Result
-
+import io.renku.jsonld.compat.implicits._
 import java.time.{Instant, LocalDate, OffsetDateTime}
 
 /** A type class that provides a conversion from a [[Cursor]] to an object of type `A`
@@ -246,7 +246,7 @@ private[jsonld] class JsonLDListDecoder[I](implicit itemDecoder: JsonLDDecoder[I
         case itemDecoder: JsonLDEntityDecoder[I] =>
           for {
             ids            <- array.cursor.as[List[EntityId]]
-            entityOrCached <- (ids map fromCacheOrFromAllEntities(cursor)).sequence[Either[DecodingFailure, *], Either[JsonLDEntity, I]]
+            entityOrCached <- (ids map fromCacheOrFromAllEntities(cursor)).sequence
             filtered       <- entityOrCached.map(entitiesFor(itemDecoder)).collect(matchingEntities).asRight
             decoded        <- filtered.map(decode(cursor.downTo)).sequence
           } yield decoded

--- a/src/main/scala/io/renku/jsonld/NamedGraph.scala
+++ b/src/main/scala/io/renku/jsonld/NamedGraph.scala
@@ -41,8 +41,8 @@ final case class NamedGraph(id: EntityId, entities: Seq[JsonLDEntityLike])
 
   override lazy val toJson: Json =
     Json.obj(
-      "@id"     -> id.asJson,
-      "@graph"  -> Json.fromValues(entities.map(_.toJson)),
+      "@id"    -> id.asJson,
+      "@graph" -> Json.fromValues(entities.map(_.toJson))
     )
 
   override lazy val entityId: Option[EntityId] = Some(id)
@@ -77,7 +77,7 @@ final case class DefaultGraph(entities: Seq[JsonLDEntityLike])
 
   override lazy val toJson: Json =
     Json.obj(
-      "@graph" -> Json.fromValues(entities.map(_.toJson)),
+      "@graph" -> Json.fromValues(entities.map(_.toJson))
     )
 
   override lazy val entityId: Option[EntityId] = None

--- a/src/main/scala/io/renku/jsonld/NamedGraph.scala
+++ b/src/main/scala/io/renku/jsonld/NamedGraph.scala
@@ -39,10 +39,11 @@ final case class NamedGraph(id: EntityId, entities: Seq[JsonLDEntityLike])
   import io.circe.Json
   import io.circe.literal._
 
-  override lazy val toJson: Json = json"""{
-    "@id":    ${id.asJson},
-    "@graph": ${entities.map(_.toJson)}
-  }"""
+  override lazy val toJson: Json =
+    Json.obj(
+      "@id"     -> id.asJson,
+      "@graph"  -> Json.fromValues(entities.map(_.toJson)),
+    )
 
   override lazy val entityId: Option[EntityId] = Some(id)
 
@@ -74,9 +75,10 @@ final case class DefaultGraph(entities: Seq[JsonLDEntityLike])
   import io.circe.Json
   import io.circe.literal._
 
-  override lazy val toJson: Json = json"""{
-    "@graph": ${entities.map(_.toJson)}
-  }"""
+  override lazy val toJson: Json =
+    Json.obj(
+      "@graph" -> Json.fromValues(entities.map(_.toJson)),
+    )
 
   override lazy val entityId: Option[EntityId] = None
 

--- a/src/main/scala/io/renku/jsonld/flatten/JsonLDArrayFlatten.scala
+++ b/src/main/scala/io/renku/jsonld/flatten/JsonLDArrayFlatten.scala
@@ -21,6 +21,7 @@ package io.renku.jsonld.flatten
 import io.renku.jsonld.JsonLD
 import io.renku.jsonld.JsonLD.{JsonLDArray, JsonLDEntity, MalformedJsonLD}
 import cats.syntax.all._
+import io.renku.jsonld.compat.implicits._
 
 trait JsonLDArrayFlatten extends JsonLDFlatten {
   self: JsonLDArray =>
@@ -30,9 +31,9 @@ trait JsonLDArrayFlatten extends JsonLDFlatten {
   override lazy val flatten: Either[MalformedJsonLD, JsonLD] = for {
     flattened <- jsons.foldLeft(Either.right[MalformedJsonLD, List[JsonLD]](List.empty[JsonLD])) {
                    case (flattened, jsonLDEntity: JsonLDEntity) =>
-                     flattened flatMap (deNest(List(jsonLDEntity), _))
+                     flattened >>= (deNest(List(jsonLDEntity), _))
                    case (flattened, JsonLDArray(jsons)) =>
-                     flattened flatMap (deNest(jsons.toList, _))
+                     flattened >>= (deNest(jsons.toList, _))
                    case (flattened, other) => flattened.map(_ ::: other :: Nil)
                  }
     validated <- checkForUniqueIds(flattened.distinct)

--- a/src/main/scala/io/renku/jsonld/flatten/JsonLDArrayFlatten.scala
+++ b/src/main/scala/io/renku/jsonld/flatten/JsonLDArrayFlatten.scala
@@ -30,9 +30,9 @@ trait JsonLDArrayFlatten extends JsonLDFlatten {
   override lazy val flatten: Either[MalformedJsonLD, JsonLD] = for {
     flattened <- jsons.foldLeft(Either.right[MalformedJsonLD, List[JsonLD]](List.empty[JsonLD])) {
                    case (flattened, jsonLDEntity: JsonLDEntity) =>
-                     flattened >>= (deNest(List(jsonLDEntity), _))
+                     flattened flatMap (deNest(List(jsonLDEntity), _))
                    case (flattened, JsonLDArray(jsons)) =>
-                     flattened >>= (deNest(jsons.toList, _))
+                     flattened flatMap (deNest(jsons.toList, _))
                    case (flattened, other) => flattened.map(_ ::: other :: Nil)
                  }
     validated <- checkForUniqueIds(flattened.distinct)

--- a/src/main/scala/io/renku/jsonld/flatten/NamedGraphFlatten.scala
+++ b/src/main/scala/io/renku/jsonld/flatten/NamedGraphFlatten.scala
@@ -22,6 +22,7 @@ import cats.syntax.all._
 import io.renku.jsonld.JsonLD._
 import io.renku.jsonld.merge.EntitiesMerger
 import io.renku.jsonld.{DefaultGraph, Graph, NamedGraph}
+import io.renku.jsonld.compat.implicits._
 
 trait NamedGraphFlatten extends JsonLDFlatten with GraphFlatten {
   self: NamedGraph =>
@@ -50,7 +51,7 @@ trait GraphFlatten extends EntitiesMerger {
 
   private def flattenEntities: Either[MalformedJsonLD, List[JsonLDEntityLike]] =
     entities.foldLeft(Either.right[MalformedJsonLD, List[JsonLDEntityLike]](List.empty[JsonLDEntityLike])) {
-      case (flattened, entity: JsonLDEntity) => flattened flatMap (deNestEntities(List(entity), _))
+      case (flattened, entity: JsonLDEntity) => flattened >>= (deNestEntities(List(entity), _))
       case (flattened, edge: JsonLDEdge)     => flattened.map(_ ::: edge :: Nil)
     }
 }

--- a/src/main/scala/io/renku/jsonld/flatten/NamedGraphFlatten.scala
+++ b/src/main/scala/io/renku/jsonld/flatten/NamedGraphFlatten.scala
@@ -50,7 +50,7 @@ trait GraphFlatten extends EntitiesMerger {
 
   private def flattenEntities: Either[MalformedJsonLD, List[JsonLDEntityLike]] =
     entities.foldLeft(Either.right[MalformedJsonLD, List[JsonLDEntityLike]](List.empty[JsonLDEntityLike])) {
-      case (flattened, entity: JsonLDEntity) => flattened >>= (deNestEntities(List(entity), _))
+      case (flattened, entity: JsonLDEntity) => flattened flatMap (deNestEntities(List(entity), _))
       case (flattened, edge: JsonLDEdge)     => flattened.map(_ ::: edge :: Nil)
     }
 }

--- a/src/main/scala/io/renku/jsonld/merge/EntitiesMerger.scala
+++ b/src/main/scala/io/renku/jsonld/merge/EntitiesMerger.scala
@@ -59,6 +59,6 @@ private[jsonld] trait EntitiesMerger {
   private def updateProperty(targetEntityId: JsonLDEntityId[EntityId]): JsonLD => JsonLD = propertyValue =>
     propertyValue.asArray.fold(JsonLD.arr(targetEntityId)) { jsonLDArr =>
       if (jsonLDArr contains targetEntityId) JsonLD.arr(jsonLDArr: _*)
-      else JsonLD.arr(jsonLDArr.appended(targetEntityId):          _*)
+      else JsonLD.arr(jsonLDArr :+ targetEntityId:          _*)
     }
 }

--- a/src/main/scala/io/renku/jsonld/merge/EntitiesMerger.scala
+++ b/src/main/scala/io/renku/jsonld/merge/EntitiesMerger.scala
@@ -59,6 +59,6 @@ private[jsonld] trait EntitiesMerger {
   private def updateProperty(targetEntityId: JsonLDEntityId[EntityId]): JsonLD => JsonLD = propertyValue =>
     propertyValue.asArray.fold(JsonLD.arr(targetEntityId)) { jsonLDArr =>
       if (jsonLDArr contains targetEntityId) JsonLD.arr(jsonLDArr: _*)
-      else JsonLD.arr(jsonLDArr :+ targetEntityId:          _*)
+      else JsonLD.arr(jsonLDArr :+ targetEntityId:                 _*)
     }
 }

--- a/src/main/scala/io/renku/jsonld/ontology/Ontology.scala
+++ b/src/main/scala/io/renku/jsonld/ontology/Ontology.scala
@@ -20,15 +20,14 @@ package io.renku.jsonld.ontology
 
 import cats.Show
 import cats.data.NonEmptyList
-import cats.evidence.{<~<, ===}
 import cats.kernel.Semigroup
 import cats.syntax.all._
 import io.renku.jsonld.JsonLDEncoder._
 import io.renku.jsonld._
+import io.renku.jsonld.compat.implicits._
 import io.renku.jsonld.ontology.DataProperty.TopDataProperty
 import io.renku.jsonld.ontology.ObjectProperty.TopObjectProperty
 import io.renku.jsonld.syntax._
-import io.renku.jsonld.compat.implicits._
 
 final case class Type(clazz:             Class,
                       objectProperties:  List[ObjectProperty],

--- a/src/main/scala/io/renku/jsonld/ontology/Ontology.scala
+++ b/src/main/scala/io/renku/jsonld/ontology/Ontology.scala
@@ -201,16 +201,16 @@ object ObjectProperty {
 
   implicit lazy val encoder: JsonLDEncoder[ObjectProperty] = JsonLDEncoder.instance {
     case ObjectProperty(id, range, domain, maybeTopProperty, maybeComment) =>
-        JsonLD.entity(
-          id,
-          EntityTypes of owl / "ObjectProperty",
-          Seq(
-            Some(rdfs / "domain" -> domain.asJsonLD),
-            Some(rdfs / "range"  -> range.asJsonLD),
-            maybeTopProperty.map(p => rdfs / "subPropertyOf" -> p.encoder(p)),
-            maybeComment.map(c => rdfs / "comment" -> c.asJsonLD)
-          ).flatten.toMap
-        )
+      JsonLD.entity(
+        id,
+        EntityTypes of owl / "ObjectProperty",
+        Seq(
+          Some(rdfs / "domain" -> domain.asJsonLD),
+          Some(rdfs / "range"  -> range.asJsonLD),
+          maybeTopProperty.map(p => rdfs / "subPropertyOf" -> p.encoder(p)),
+          maybeComment.map(c => rdfs / "comment" -> c.asJsonLD)
+        ).flatten.toMap
+      )
   }
 }
 

--- a/src/main/scala/io/renku/jsonld/ontology/Ontology.scala
+++ b/src/main/scala/io/renku/jsonld/ontology/Ontology.scala
@@ -20,6 +20,7 @@ package io.renku.jsonld.ontology
 
 import cats.Show
 import cats.data.NonEmptyList
+import cats.evidence.{<~<, ===}
 import cats.kernel.Semigroup
 import cats.syntax.all._
 import io.renku.jsonld.JsonLDEncoder._
@@ -27,6 +28,7 @@ import io.renku.jsonld._
 import io.renku.jsonld.ontology.DataProperty.TopDataProperty
 import io.renku.jsonld.ontology.ObjectProperty.TopObjectProperty
 import io.renku.jsonld.syntax._
+import io.renku.jsonld.compat.implicits._
 
 final case class Type(clazz:             Class,
                       objectProperties:  List[ObjectProperty],
@@ -200,16 +202,16 @@ object ObjectProperty {
 
   implicit lazy val encoder: JsonLDEncoder[ObjectProperty] = JsonLDEncoder.instance {
     case ObjectProperty(id, range, domain, maybeTopProperty, maybeComment) =>
-      JsonLD.entity(
-        id,
-        EntityTypes of owl / "ObjectProperty",
-        Seq(
-          Some(rdfs / "domain" -> domain.asJsonLD),
-          Some(rdfs / "range"  -> range.asJsonLD),
-          maybeTopProperty.map(p => rdfs / "subPropertyOf" -> p.asJsonLD),
-          maybeComment.map(c => rdfs / "comment" -> c.asJsonLD)
-        ).flatten.toMap
-      )
+        JsonLD.entity(
+          id,
+          EntityTypes of owl / "ObjectProperty",
+          Seq(
+            Some(rdfs / "domain" -> domain.asJsonLD),
+            Some(rdfs / "range"  -> range.asJsonLD),
+            maybeTopProperty.map(p => rdfs / "subPropertyOf" -> p.encoder(p)),
+            maybeComment.map(c => rdfs / "comment" -> c.asJsonLD)
+          ).flatten.toMap
+        )
   }
 }
 
@@ -296,7 +298,7 @@ object DataProperty {
           Seq(
             Some(rdfs / "domain" -> domain.asJsonLD),
             Some(rdfs / "range"  -> range.asJsonLD),
-            maybeTopProperty.map(p => rdfs / "subPropertyOf" -> p.asJsonLD),
+            maybeTopProperty.map(p => rdfs / "subPropertyOf" -> p.encoder(p)),
             maybeComment.map(c => rdfs / "comment" -> c.asJsonLD)
           ).flatten.toMap
         )

--- a/src/main/scala/io/renku/jsonld/parser/JsonLDParser.scala
+++ b/src/main/scala/io/renku/jsonld/parser/JsonLDParser.scala
@@ -69,7 +69,7 @@ private class JsonLDParser() extends Parser {
     } yield JsonLD.JsonLDEntity(id, types, properties.toMap, reverse)
 
     private def extractProperties(jsonObject: JsonObject) =
-      jsonObject.toMap
+      jsonObject.toMap.view
         .filterKeys(key => key != "@id" && key != "@type" && key != "@reverse")
         .toList
         .map(toPropsAndValues)
@@ -99,7 +99,7 @@ private class JsonLDParser() extends Parser {
     }
 
     private def parseReverseObject(jsonObject: JsonObject): Either[ParsingFailure, Reverse] =
-      jsonObject.toMap
+      jsonObject.toMap.view
         .filterKeys(notReserved)
         .toList match {
         case Nil => ParsingFailure("Malformed entity's @reverse property - no properties defined").asLeft[Reverse]
@@ -127,7 +127,7 @@ private class JsonLDParser() extends Parser {
       .bimap(ParsingFailure(s"Could not parse @id: $entityId", _), identity)
 
   private def toJsonLDEdge(entityId: Json, props: Map[String, Json]): Either[ParsingFailure, JsonLD] = {
-    val propsWithoutId = props.filterKeys(_ != "@id")
+    val propsWithoutId = props.view.filterKeys(_ != "@id")
 
     def extractId(id: EntityId)(json: Json) = json.asObject
       .flatMap(_.toMap.get("@id"))

--- a/src/main/scala/io/renku/jsonld/parser/JsonLDParser.scala
+++ b/src/main/scala/io/renku/jsonld/parser/JsonLDParser.scala
@@ -47,12 +47,12 @@ private class JsonLDParser() extends Parser {
     (propsMap.get("@id"), propsMap.get("@type"), propsMap.get("@reverse"), propsMap.get("@value")) match {
       case (Some(entityId), Some(types), maybeReverse, None) => jsonObject.toJsonLdEntity(entityId, types, maybeReverse)
       case (Some(entityId), None, None, None) if !propsMap.keys.exists(notReserved) => toJsonLDEntityId(entityId)
-      case (Some(entityId), None, None, None)    => toJsonLDEdge(entityId, propsMap)
-      case (None, maybeTypes, None, Some(value)) => toJsonLDValue(maybeTypes, value)
-      case (Some(_), None, Some(_), None)        => ParsingFailure("Entity with reverse but no type").asLeft[JsonLD]
-      case (None, _, _, _)                       => ParsingFailure("Entity without @id").asLeft[JsonLD]
-      case (Some(_), Some(_), _, Some(_))        => ParsingFailure("Invalid entity").asLeft[JsonLD]
-      case (Some(_), None, _, Some(_)) => ParsingFailure("Entity with @id and @value but no @type").asLeft[JsonLD]
+      case (Some(entityId), None, None, None)                                       => toJsonLDEdge(entityId, propsMap)
+      case (None, maybeTypes, None, Some(value))                                    => toJsonLDValue(maybeTypes, value)
+      case (Some(_), None, Some(_), None) => ParsingFailure("Entity with reverse but no type").asLeft[JsonLD]
+      case (None, _, _, _)                => ParsingFailure("Entity without @id").asLeft[JsonLD]
+      case (Some(_), Some(_), _, Some(_)) => ParsingFailure("Invalid entity").asLeft[JsonLD]
+      case (Some(_), None, _, Some(_))    => ParsingFailure("Entity with @id and @value but no @type").asLeft[JsonLD]
     }
   }
 

--- a/src/test/scala/io/renku/jsonld/DefaultGraphSpec.scala
+++ b/src/test/scala/io/renku/jsonld/DefaultGraphSpec.scala
@@ -20,6 +20,7 @@ package io.renku.jsonld
 
 import cats.data.NonEmptyList
 import cats.syntax.all._
+import io.circe.Json
 import io.circe.literal._
 import io.renku.jsonld.JsonLD.JsonLDEntity
 import io.renku.jsonld.generators.Generators.Implicits._
@@ -113,9 +114,9 @@ class DefaultGraphSpec extends AnyWordSpec with should.Matchers with ScalaCheckP
 
     "turn the given DefaultGraph into JSON" in {
       forAll { (graph: DefaultGraph) =>
-        graph.toJson shouldBe json"""{
-          "@graph": ${graph.entities.map(_.toJson)}
-        }"""
+        graph.toJson shouldBe Json.obj(
+          "@graph" -> Json.fromValues(graph.entities.map(_.toJson))
+        )
       }
     }
   }

--- a/src/test/scala/io/renku/jsonld/JsonLDFlattenSpec.scala
+++ b/src/test/scala/io/renku/jsonld/JsonLDFlattenSpec.scala
@@ -171,7 +171,7 @@ class JsonLDFlattenSpec extends AnyWordSpec with ScalaCheckPropertyChecks with s
        */
 
       def replaceEntityProperty(properties: Map[Property, JsonLD], property: Property, entity: JsonLDEntity) =
-        properties.removed(property) + (property -> JsonLDEntityId(entity.id))
+        properties - property + (property -> JsonLDEntityId(entity.id))
 
       forAll {
         (entity0:  JsonLDEntity,

--- a/src/test/scala/io/renku/jsonld/NamedGraphSpec.scala
+++ b/src/test/scala/io/renku/jsonld/NamedGraphSpec.scala
@@ -20,6 +20,7 @@ package io.renku.jsonld
 
 import cats.data.NonEmptyList
 import cats.syntax.all._
+import io.circe.Json
 import io.circe.literal._
 import io.renku.jsonld.JsonLD.JsonLDEntity
 import io.renku.jsonld.generators.Generators.Implicits._
@@ -127,10 +128,10 @@ class NamedGraphSpec extends AnyWordSpec with should.Matchers with ScalaCheckPro
 
     "turn the given NamedGraph into JSON" in {
       forAll { (graph: NamedGraph) =>
-        graph.toJson shouldBe json"""{
-          "@id":    ${graph.id},
-          "@graph": ${graph.entities.map(_.toJson)}
-        }"""
+        graph.toJson shouldBe Json.obj(
+          "@id"   -> graph.id.asJson,
+          "@graph" -> Json.fromValues(graph.entities.map(_.toJson))
+        )
       }
     }
   }

--- a/src/test/scala/io/renku/jsonld/NamedGraphSpec.scala
+++ b/src/test/scala/io/renku/jsonld/NamedGraphSpec.scala
@@ -129,7 +129,7 @@ class NamedGraphSpec extends AnyWordSpec with should.Matchers with ScalaCheckPro
     "turn the given NamedGraph into JSON" in {
       forAll { (graph: NamedGraph) =>
         graph.toJson shouldBe Json.obj(
-          "@id"   -> graph.id.asJson,
+          "@id"    -> graph.id.asJson,
           "@graph" -> Json.fromValues(graph.entities.map(_.toJson))
         )
       }


### PR DESCRIPTION
- added kind-projector dependency for type ascriptions without # magic
- added a scala version dependent `implicits` object containing helper implicits for scala 2.12, for scala 2.13 is left empty
- added some necessary (for 2.12) type ascriptions
- for creating jsons with Circe I used `Json.obj(...)` instead of `json"..."` macro (because macro expansion err in 2.12)